### PR TITLE
Add auto-generated email with new password in case of password resets

### DIFF
--- a/OxbridgeBackend/src/database/repository/UserRepo.ts
+++ b/OxbridgeBackend/src/database/repository/UserRepo.ts
@@ -74,12 +74,6 @@ export default class UserRepo {
         const keystore = await KeystoreRepo.create(user._id, accessTokenKey, refreshTokenKey);
         return { user: user, keystore: keystore };
       }
-
-      public static async updatePassword(user: User): Promise<any> {
-        return UserModel.updateOne({ _id: user._id }, { password: user.password })
-          .lean<User>()
-          .exec();
-      }
     
       public static async updateInfo(user: User): Promise<any> {
         return UserModel.updateOne({ _id: user._id }, { $set: { ...user } })

--- a/OxbridgeBackend/src/database/repository/UserRepo.ts
+++ b/OxbridgeBackend/src/database/repository/UserRepo.ts
@@ -75,11 +75,10 @@ export default class UserRepo {
         return { user: user, keystore: keystore };
       }
 
-      public static async updatePassword(user: User): Promise<User> {
-        await UserModel.updateOne({ _id: user._id }, { password: user.password })
-          .lean()
+      public static async updatePassword(user: User): Promise<any> {
+        return UserModel.updateOne({ _id: user._id }, { password: user.password })
+          .lean<User>()
           .exec();
-        return user.toObject();
       }
     
       public static async updateInfo(user: User): Promise<any> {

--- a/OxbridgeBackend/src/database/repository/UserRepo.ts
+++ b/OxbridgeBackend/src/database/repository/UserRepo.ts
@@ -74,6 +74,13 @@ export default class UserRepo {
         const keystore = await KeystoreRepo.create(user._id, accessTokenKey, refreshTokenKey);
         return { user: user, keystore: keystore };
       }
+
+      public static async updatePassword(user: User): Promise<User> {
+        await UserModel.updateOne({ _id: user._id }, { password: user.password })
+          .lean()
+          .exec();
+        return user.toObject();
+      }
     
       public static async updateInfo(user: User): Promise<any> {
         return UserModel.updateOne({ _id: user._id }, { $set: { ...user } })

--- a/OxbridgeBackend/src/mail/EmailPasswordReset.ts
+++ b/OxbridgeBackend/src/mail/EmailPasswordReset.ts
@@ -1,0 +1,35 @@
+import User from "../database/model/User";
+import { transporter } from './';
+
+/**
+  * The class handles sending out the reset password
+  * to users who have asked for a new password.
+  */
+
+export default class EmailPasswordReset{
+
+    user: User;
+    password: String;
+
+    constructor(user: User, password: String){
+        this.user = user;
+        this.password = password;
+
+        try{
+            this.task();
+        }catch(e){
+            console.error(' error: ' + e);
+        }
+    }
+
+    async task(): Promise<void> {
+        const info = await transporter.sendMail({
+            from: '"Tregatta" <tregattasonderborg@gmail.com>',
+            to: this.user.email,
+            subject: "Anmodning om en ny adgangskode",
+            text: "Din konto har anmodet om en ny midlertidig adgangskode. Din nye adgangskode er " + this.password,
+            html: "<strong>Din konto har anmodet om en ny midlertidig adgangskode. Din nye adgangskode er " + this.password + "</strong>",
+            headers: { 'x-myheader': 'Tregatta Event' }
+          });
+    }
+}

--- a/OxbridgeBackend/src/routes/v1/access/reset.ts
+++ b/OxbridgeBackend/src/routes/v1/access/reset.ts
@@ -31,7 +31,7 @@ router.post(
         const passwordHash = await bcrypt.hash(password, 10);
 
         user.password = passwordHash;
-        await UserRepo.updatePassword(user);
+        await UserRepo.updateInfo(user);
 
         new EmailPasswordReset(user, password);
         new SuccessMsgResponse('Password reset successfully').send(res);

--- a/OxbridgeBackend/src/routes/v1/access/reset.ts
+++ b/OxbridgeBackend/src/routes/v1/access/reset.ts
@@ -1,0 +1,50 @@
+import express from 'express';
+import { SuccessResponse } from '../../../core/ApiResponse';
+import { RoleRequest } from 'app-request';
+import crypto from 'crypto';
+import UserRepo from '../../../database/repository/UserRepo';
+import { BadRequestError } from '../../../core/ApiError';
+import User from '../../../database/model/User';
+import { createTokens } from '../../../auth/authUtils';
+import validator from '../../../helpers/validator';
+import schema from './schema';
+import asyncHandler from '../../../helpers/asyncHandler';
+import bcrypt from 'bcrypt';
+import _ from 'lodash';
+import { RoleCode } from '../../../database/model/Role';
+
+const router = express.Router();
+
+/**
+  * Resets the password on an 
+  * existing user.
+  * Route: POST /v1/reset
+  * Return: 
+  */
+
+router.post(
+    '/',
+    validator(schema.email),
+    asyncHandler(async (req: RoleRequest, res) => {
+        const user = await UserRepo.findByEmail(req.body.email);
+        if (!user) throw new BadRequestError('User does not exist');
+
+        const password = crypto.randomBytes(16).toString('hex');
+        const passwordHash = await bcrypt.hash(password, 10);
+
+        
+
+        const updatedUser = await UserRepo.updatePassword(
+            {
+                email: req.body.email,
+                password: passwordHash,
+            } as User,
+        );
+
+        new SuccessResponse('Password reset successfully', {
+            user: _.pick(updatedUser, ['_id', 'email', 'roles']),
+        }).send(res);
+    }),
+);
+
+export default router;

--- a/OxbridgeBackend/src/routes/v1/access/reset.ts
+++ b/OxbridgeBackend/src/routes/v1/access/reset.ts
@@ -4,14 +4,12 @@ import { RoleRequest } from 'app-request';
 import crypto from 'crypto';
 import UserRepo from '../../../database/repository/UserRepo';
 import { BadRequestError } from '../../../core/ApiError';
-import User from '../../../database/model/User';
-import { createTokens } from '../../../auth/authUtils';
 import validator from '../../../helpers/validator';
 import schema from './schema';
 import asyncHandler from '../../../helpers/asyncHandler';
 import bcrypt from 'bcrypt';
 import _ from 'lodash';
-import { RoleCode } from '../../../database/model/Role';
+import EmailPasswordReset from '../../../mail/EmailPasswordReset';
 
 const router = express.Router();
 
@@ -35,6 +33,7 @@ router.post(
         user.password = passwordHash;
         await UserRepo.updatePassword(user);
 
+        new EmailPasswordReset(user, password);
         new SuccessMsgResponse('Password reset successfully').send(res);
     }),
 );

--- a/OxbridgeBackend/src/routes/v1/access/reset.ts
+++ b/OxbridgeBackend/src/routes/v1/access/reset.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { SuccessResponse } from '../../../core/ApiResponse';
+import { SuccessMsgResponse } from '../../../core/ApiResponse';
 import { RoleRequest } from 'app-request';
 import crypto from 'crypto';
 import UserRepo from '../../../database/repository/UserRepo';
@@ -32,18 +32,10 @@ router.post(
         const password = crypto.randomBytes(16).toString('hex');
         const passwordHash = await bcrypt.hash(password, 10);
 
-        
+        user.password = passwordHash;
+        await UserRepo.updatePassword(user);
 
-        const updatedUser = await UserRepo.updatePassword(
-            {
-                email: req.body.email,
-                password: passwordHash,
-            } as User,
-        );
-
-        new SuccessResponse('Password reset successfully', {
-            user: _.pick(updatedUser, ['_id', 'email', 'roles']),
-        }).send(res);
+        new SuccessMsgResponse('Password reset successfully').send(res);
     }),
 );
 

--- a/OxbridgeBackend/src/routes/v1/access/schema.ts
+++ b/OxbridgeBackend/src/routes/v1/access/schema.ts
@@ -6,6 +6,9 @@ export default {
         email: Joi.string().email().required(),
         password: Joi.string().required().min(6),
     }),
+    email: Joi.object().keys({
+        email: Joi.string().email().required(),
+    }),
     refreshToken: Joi.object().keys({
         refreshToken: Joi.string().required().min(1),
     }),

--- a/OxbridgeBackend/src/routes/v1/index.ts
+++ b/OxbridgeBackend/src/routes/v1/index.ts
@@ -4,6 +4,7 @@ import signup from './access/signup';
 import login from './access/login';
 import logout from './access/logout';
 import token from './access/token';
+import reset from './access/reset';
 import eventUser from './event/user';
 import eventAdmin from './event/admin';
 import eventRegistrationUser from './event_registration/user';
@@ -33,6 +34,7 @@ router.use('/signup', signup);
 router.use('/login', login);
 router.use('/logout', logout);
 router.use('/token', token);
+router.use('/reset', reset);
 
 // Event
 router.use('/events', eventUser);

--- a/OxbridgeBackend/src/routes/v1/user/schema.ts
+++ b/OxbridgeBackend/src/routes/v1/user/schema.ts
@@ -11,7 +11,6 @@ export default {
     updateUser: Joi.object().keys({
         firstname: Joi.string().required().min(3),
         lastname: Joi.string().required().min(3),
-        email: Joi.string().email().required(),
         password: Joi.string().required().min(6),
     }),
     userId: Joi.object().keys({

--- a/OxbridgeBackend/src/routes/v1/user/user.ts
+++ b/OxbridgeBackend/src/routes/v1/user/user.ts
@@ -1,11 +1,18 @@
 import express from 'express';
 import { SuccessResponse } from '../../../core/ApiResponse';
-import { NoDataError } from '../../../core/ApiError';
+import { AuthFailureError, NoDataError } from '../../../core/ApiError';
 import validator, { ValidationSource } from '../../../helpers/validator';
 import schema from './schema';
 import asyncHandler from '../../../helpers/asyncHandler';
 import { ProtectedRequest } from 'app-request';
 import UserRepo from '../../../database/repository/UserRepo';
+import { Types } from 'mongoose';
+import { getAccessToken } from '../../../auth/authUtils';
+import JWT from '../../../core/JWT';
+import bcrypt from 'bcrypt';
+import crypto from 'crypto';
+import { createTokens } from '../../../auth/authUtils';
+import _ from 'lodash';
 
 const router = express.Router();
 
@@ -24,5 +31,27 @@ router.get(
         return new SuccessResponse('success', user).send(res);
     }),
 );
+
+router.put(
+  '/',
+  validator(schema.updateUser),
+  asyncHandler(async (req: ProtectedRequest, res) => {
+        //Retrieve the payload from the authentication header
+        req.accessToken = getAccessToken(req.headers.authorization); // Express headers are auto converted to lowercase
+        const payload = await JWT.validate(req.accessToken);
+
+        //Retrieve the user from the user id in the payload
+        const user = await UserRepo.findById(new Types.ObjectId(payload.sub));
+        if (!user) throw new AuthFailureError('User not registered');
+        req.user = user;
+
+        if(req.body.firstname) user.firstname = req.body.firstname;
+        if(req.body.lastname) user.lastname = req.body.lastname;
+        if(req.body.password) await bcrypt.hash(req.body.password, 10);
+
+        await UserRepo.updateInfo(user);
+        return new SuccessResponse('User details updated successfully', _.pick(user, ['_id', 'email', 'roles', 'firstname', 'lastname']));
+  })
+)
 
 export default router;


### PR DESCRIPTION
As described in issue 5: https://github.com/Islendingurinn/OxbridgeProject/issues/5

- /v1/reset route triggers this reset with email body
- The route handles then the password reset and sends out an email to the user email

Additional changes:
- Implemented a route to change user details (in case of changing from the temporary password, or changing first/last name)